### PR TITLE
Get dvsource-v4l2-other working with the HDMI2USB device

### DIFF
--- a/dvsource-v4l2-other.py
+++ b/dvsource-v4l2-other.py
@@ -187,7 +187,7 @@ def launch_gstreamer():
         # -----------------------------------
         {True:
             # Read the v4l2 input and decode it if it's a mjpeg input
-            "v4l2src ! " +
+            "v4l2src device=%s ! " % args.device +
             args.caps +
             "decodebin ! ",
          False:

--- a/dvsource-v4l2-other.py
+++ b/dvsource-v4l2-other.py
@@ -231,6 +231,10 @@ def launch_gstreamer():
             "videorate ! video/x-raw,framerate=\(fraction\)25/1 !",
         }[args.system] +
         " " +
+        # FIXME: Check which color space is needed by PAL verse NSTC.
+        # Convert to color space needed by dvswitch
+        "videoconvert ! video/x-raw,format=\(string\)I420 !" +
+        " " +
         ["", "tee name=t ! "][args.display] +
         " " +
         "queue leaky=downstream max-size-buffers=1 ! " +


### PR DESCRIPTION
* Actually passes the `--device` argument to the v4l2src element.
* Force colorspace to I420 otherwise dvswitch complains with; `[dvvideo @ 0x1dc5400] could not find dv frame profile`.