### PR TITLE
More fixes to get the HDMI2USB working

### DIFF
--- a/dvsource-v4l2-other.py
+++ b/dvsource-v4l2-other.py
@@ -211,15 +211,16 @@ def launch_gstreamer():
         # http://www.sciencemedianetwork.org/wiki/Tutorials/Video/Pixel_Aspect_Ratio
         {"ntsc-4:3": 
             # Convert to 4:3 with non-square pixels (was 10.0/11 ~= 0.91, now 8.0/9 ~= 0.88)
-            "videoscale ! video/x-raw,width=720,height=480,pixel-aspect-ratio=\(fraction\)10/11 !",
+            "videoscale ! video/x-raw,width=720,height=480,pixel-aspect-ratio=\(fraction\)8/9 !",
          "ntsc-16:9": 
-            # Convert to 4:3 with non-square pixels (was 40.0/33 ~= 1.21, now 32.0/27 ~= 1.19)
-            "videoscale ! video/x-raw,width=720,height=480,pixel-aspect-ratio=\(fraction\)40/33 !",
+            # Convert to 16:9 with non-square pixels (was 40.0/33 ~= 1.21, now 32.0/27 ~= 1.19)
+            "videoscale ! video/x-raw,width=720,height=480,pixel-aspect-ratio=\(fraction\)32/27 !",
          "pal-4:3":
             # Convert to 4:3 with non-square pixels (was 59.0/54 ~= 1.09 == ITU-PAR, now 16.0/15 ~= 1.07 == NLE-PAR used by Final Cut / Adobe)
+            # I420 == works, Y41B == works, Y42B == not working
             "videoscale ! video/x-raw,width=720,height=576,pixel-aspect-ratio=\(fraction\)16/15 !",
          "pal-16:9":
-            # Convert to 4:3 with non-square pixels (was 118.0/81 ~= 1.46 == anamorphic 'ITU', now 64.0/45 ~= 1.42 == anamorphic 'NLE')
+            # Convert to 16:9 with non-square pixels (was 118.0/81 ~= 1.46 == anamorphic 'ITU', now 64.0/45 ~= 1.42 == anamorphic 'NLE')
             "videoscale ! video/x-raw,width=720,height=576,pixel-aspect-ratio=\(fraction\)64/45 !",
         }["%s-%s" % (args.system, args.aspect)] +
         " " +

--- a/dvsource-v4l2-other.py
+++ b/dvsource-v4l2-other.py
@@ -218,7 +218,7 @@ def launch_gstreamer():
          "pal-4:3":
             # Convert to 4:3 with non-square pixels (was 59.0/54 ~= 1.09 == ITU-PAR, now 16.0/15 ~= 1.07 == NLE-PAR used by Final Cut / Adobe)
             "videoscale ! video/x-raw,width=720,height=576,pixel-aspect-ratio=\(fraction\)16/15 !",
-         "pal-4:3":
+         "pal-16:9":
             # Convert to 4:3 with non-square pixels (was 118.0/81 ~= 1.46 == anamorphic 'ITU', now 64.0/45 ~= 1.42 == anamorphic 'NLE')
             "videoscale ! video/x-raw,width=720,height=576,pixel-aspect-ratio=\(fraction\)64/45 !",
         }["%s-%s" % (args.system, args.aspect)] +

--- a/dvsource-v4l2-other.py
+++ b/dvsource-v4l2-other.py
@@ -232,9 +232,11 @@ def launch_gstreamer():
             "videorate ! video/x-raw,framerate=\(fraction\)25/1 !",
         }[args.system] +
         " " +
-        # FIXME: Check which color space is needed by PAL verse NSTC.
         # Convert to color space needed by dvswitch
-        "videoconvert ! video/x-raw,format=\(string\)I420 !" +
+        # For PAL, either I420 or Y41B works.
+        # For NTSC, only Y41B seems to work.
+        # Y42B doesn't seem supported by dvswitch at all.
+        "videoconvert ! video/x-raw,format=\(string\)Y41B !" +
         " " +
         ["", "tee name=t ! "][args.display] +
         " " +


### PR DESCRIPTION
 * Fix the aspect ratio formatting.
 * Use Y41B format rather than I420 because it always seems to work.